### PR TITLE
Fix deprecated usage of erlang:now and crypto:hash 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ ebin/*.beam
 .settings
 _build
 .DS_Store
+rebar.config
+rebar.lock
+

--- a/src/gridfs.erl
+++ b/src/gridfs.erl
@@ -152,7 +152,7 @@ insert(Bucket, Bson, FileData) when is_binary(FileData) ->
 	insert(ChunksColl, ObjectId, 0, FileData),
 	Md5 = list_to_binary(bin_to_hexstr(crypto:hash(md5,FileData))),
     ListBson=tuple_to_list(Bson),
-    ListFileAttr=['_id', ObjectId, length, size(FileData), chunkSize, ?CHUNK_SIZE, uploadDate, now(), md5, Md5],
+    ListFileAttr=['_id', ObjectId, length, size(FileData), chunkSize, ?CHUNK_SIZE, uploadDate, erlang:timestamp(), md5, Md5],
     UnifiedList=lists:append([ListFileAttr, ListBson]),
 	mongo:insert(FilesColl, list_to_tuple(UnifiedList));
 insert(Bucket, Bson, IoStream) ->
@@ -164,7 +164,7 @@ insert(Bucket, Bson, IoStream) ->
 	file:close(IoStream),
     ListBson=tuple_to_list(Bson),
     ListFileAttr=['_id', ObjectId, length, FileSize, chunkSize, ?CHUNK_SIZE, 
-							 uploadDate, now(), md5, Md5Str],
+							 uploadDate, erlang:timestamp(), md5, Md5Str],
     UnifiedList=lists:append([ListFileAttr, ListBson]),
 	mongo:insert(FilesColl, list_to_tuple(UnifiedList)).
 


### PR DESCRIPTION
- Fix deprecated usage of `erlang:now` and` crypto:md5*`
  - Use replacement functions for hashing from **crypto** module 
  - Use `erlang:timestamp/0` instead of` erlang:now/0`

